### PR TITLE
feat: Disable text boundaries

### DIFF
--- a/src/electron/office/office_client.cc
+++ b/src/electron/office/office_client.cc
@@ -30,6 +30,7 @@
 #include "shell/common/gin_converters/std_converter.h"
 #include "third_party/blink/public/web/blink.h"
 #include "third_party/libreofficekit/LibreOfficeKit.hxx"
+#include "third_party/libreofficekit/LibreOfficeKitEnums.h"
 #include "v8-json.h"
 #include "v8/include/v8-function.h"
 #include "v8/include/v8-isolate.h"
@@ -176,6 +177,9 @@ std::string OfficeClient::GetLastError() {
 
 v8::Local<v8::Value> OfficeClient::LoadDocument(v8::Isolate* isolate,
                                                 const std::string& path) {
+   office_->setOptionalFeatures(
+      LibreOfficeKitOptionalFeatures::LOK_FEATURE_NO_TILED_ANNOTATIONS);
+
   lok::Document* doc = GetDocument(path);
 
   if (!doc) {


### PR DESCRIPTION
Disables text boundary boxes when loading the document.

NOTE: IF you manually enable the text boundary boxes via `.uno:ViewBounds` then save the document the boxes will still appear. This is expected imo. New documents opened will NOT have the boxes though.