### PR TITLE
Fix use-after-free, null pointer access, and other memory related problems in DocumentClient

### DIFF
--- a/src/electron/office/document_client.h
+++ b/src/electron/office/document_client.h
@@ -73,8 +73,8 @@ class DocumentClient : public gin::Wrappable<DocumentClient> {
   std::vector<std::string> GetTextSelection(const std::string& mime_type,
                                             gin::Arguments* args);
   void SetTextSelection(int n_type, int n_x, int n_y);
-  std::string GetPartName(int n_part);
-  std::string GetPartHash(int n_part);
+  v8::Local<v8::Value> GetPartName(int n_part, gin::Arguments* args);
+  v8::Local<v8::Value> GetPartHash(int n_part, gin::Arguments* args);
   void SendDialogEvent(uint64_t n_window_id, gin::Arguments* args);
   v8::Local<v8::Value> GetSelectionTypeAndText(const std::string& mime_type,
                                                gin::Arguments* args);


### PR DESCRIPTION
Fixed the thing I mentioned to you before @whutchinson98 and similar cases.

Also ensured that the objects transformed to JSON strings don't cause memory leaks.