### PR TITLE
Fix PNG copy crash

### DIFF
--- a/src/electron/office/BUILD.gn
+++ b/src/electron/office/BUILD.gn
@@ -132,6 +132,7 @@ source_set("office_lib") {
     "//base",
     "//gin",
     "//ui/gfx/geometry", # DocumentClient
+    "//ui/gfx/codec",
   ]
 
   configs += [ ":electron_config" ]

--- a/src/electron/office/document_client.cc
+++ b/src/electron/office/document_client.cc
@@ -49,6 +49,7 @@
 #include "v8/include/v8-json.h"
 #include "v8/include/v8-local-handle.h"
 #include "v8/include/v8-primitive.h"
+#include "ui/gfx/codec/png_codec.h"
 
 namespace electron::office {
 gin::WrapperInfo DocumentClient::kWrapperInfo = {gin::kEmbedderNativeGin};
@@ -313,8 +314,9 @@ void DocumentClient::OnClipboardChanged() {
 
       writer.WriteText(converted_data);
     } else if (mime_type == "image/png") {
-      writer.WritePickledData(base::Pickle(out_streams[i], buffer_size),
-                              ui::ClipboardFormatType::PngType());
+      SkBitmap bitmap;
+      gfx::PNGCodec::Decode(reinterpret_cast<unsigned char*>(out_streams[i]), buffer_size, &bitmap);
+      writer.WriteImage(std::move(bitmap));
     }
   }
 }


### PR DESCRIPTION
Seems like on macOS the pickled data solution doesn't work, ever. But a riff on the old-style WriteImage works. (Said code ultimately gets converted back to PNG, love Chromium 😂)