### PR TITLE
[MACRO-1580] Undo/Redo Tile Invalidation

### DIFF
--- a/src/electron/office/office_web_plugin.cc
+++ b/src/electron/office/office_web_plugin.cc
@@ -361,6 +361,10 @@ blink::WebInputEventResult OfficeWebPlugin::HandleKeyEvent(
         return type == blink::WebInputEvent::Type::kKeyUp
                    ? blink::WebInputEventResult::kHandledApplication
                    : HandleCutCopyEvent(".uno:Cut");
+      case office::DomCode::US_Z:
+        return type == blink::WebInputEvent::Type::kKeyUp
+                   ? blink::WebInputEventResult::kHandledApplication
+                   : event.GetModifiers() & office::Modifiers::kShiftKey ? HandleUndoRedoEvent(".uno:Redo") : HandleUndoRedoEvent(".uno:Undo");
     }
   }
 
@@ -387,6 +391,11 @@ blink::WebInputEventResult OfficeWebPlugin::HandleKeyEvent(
                          : LOK_KEYEVENT_KEYINPUT,
                      event.text[0], lok_key_code));
 
+  return blink::WebInputEventResult::kHandledApplication;
+}
+blink::WebInputEventResult OfficeWebPlugin::HandleUndoRedoEvent(std::string event) {
+  document_client_->PostUnoCommandInternal(event, nullptr, true);
+  InvalidateAllTiles();
   return blink::WebInputEventResult::kHandledApplication;
 }
 

--- a/src/electron/office/office_web_plugin.h
+++ b/src/electron/office/office_web_plugin.h
@@ -180,6 +180,7 @@ class OfficeWebPlugin : public blink::WebPlugin,
                                             ui::Cursor* cursor);
   blink::WebInputEventResult HandleCutCopyEvent(std::string event);
   blink::WebInputEventResult HandlePasteEvent();
+  blink::WebInputEventResult HandleUndoRedoEvent(std::string event);
   bool HandleMouseEvent(blink::WebInputEvent::Type type,
                         gfx::PointF position,
                         int modifiers,


### PR DESCRIPTION
- Handle undo/redo in office_web_plugin to explicitly invalidate all tiles

https://github.com/coparse-inc/electron-libreoffice/assets/6412775/900476fb-df67-485e-a1df-3e759ae6ffcd
