### PR TITLE
MACRO-1593 Fix Copy Keyboard Shortcut

### DIFF
--- a/src/electron/office/office_web_plugin.cc
+++ b/src/electron/office/office_web_plugin.cc
@@ -350,7 +350,7 @@ blink::WebInputEventResult OfficeWebPlugin::HandleKeyEvent(
       case office::DomCode::US_W:
         return blink::WebInputEventResult::kNotHandled;
       case office::DomCode::US_C:
-        return type == blink::WebInputEvent::Type::kRawKeyDown
+        return type == blink::WebInputEvent::Type::kKeyUp
                    ? blink::WebInputEventResult::kHandledApplication
                    : HandleCutCopyEvent(".uno:Copy");
       case office::DomCode::US_V:


### PR DESCRIPTION
- Fix copy keyboard shortcut by fixing incorrect switch case


https://github.com/coparse-inc/electron-libreoffice/assets/6412775/546189fe-31ec-4c97-a41d-13d2585c41af

