### PR TITLE
Modify gitattributes so line endings are preserved in windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,7 @@
-* text eol=lf
+* text=auto eol=lf
+*.rc binary
+*.gif binary
+*.icns binary
+*.ico binary
+*.asar binary
 *.png binary


### PR DESCRIPTION
Was experiencing issues when pulling down even after configuring auto crlf to false because some of these files were being treated as text. This will have them match the index.