### PR TITLE
Adds an upstream patch to fix annoying crashes

### DIFF
--- a/src/electron/patches/chromium/.patches
+++ b/src/electron/patches/chromium/.patches
@@ -126,3 +126,4 @@ cherry-pick-51daffbf5cd8.patch
 dpwa_enable_window_controls_overlay_by_default.patch
 create_browser_v8_snapshot_file_name_fuse.patch
 cherry-pick-1eb1e18ad41d.patch
+cherry-pick-db31a3b7bf33.patch

--- a/src/electron/patches/chromium/.patches
+++ b/src/electron/patches/chromium/.patches
@@ -127,3 +127,4 @@ dpwa_enable_window_controls_overlay_by_default.patch
 create_browser_v8_snapshot_file_name_fuse.patch
 cherry-pick-1eb1e18ad41d.patch
 cherry-pick-db31a3b7bf33.patch
+ignore_mouse_wheel_dcheck.patch

--- a/src/electron/patches/chromium/cherry-pick-db31a3b7bf33.patch
+++ b/src/electron/patches/chromium/cherry-pick-db31a3b7bf33.patch
@@ -1,0 +1,49 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Kenneth Russell <kbr@chromium.org>
+Date: Mon, 09 Jan 2023 18:42:16 +0000
+Subject: [PATCH] Temporarily comment out incorrectly-firing DCHECKs.
+
+These are firing in developers' builds while investigating unrelated
+bugs. Comment them out and add TODOs about re-enabling them,
+referencing the associated bug.
+
+Bug: chromium:1356794
+Change-Id: I51aa803500420fc0e930bad913fb3789b3543818
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4144309
+Reviewed-by: Jonathan Ross <jonross@chromium.org>
+Commit-Queue: Kenneth Russell <kbr@chromium.org>
+Cr-Commit-Position: refs/heads/main@{#1090420}
+---
+
+diff --git a/cc/metrics/average_lag_tracker.cc b/cc/metrics/average_lag_tracker.cc
+index a5e4968..5fe6855 100644
+--- a/cc/metrics/average_lag_tracker.cc
++++ b/cc/metrics/average_lag_tracker.cc
+@@ -165,16 +165,23 @@
+ }
+ 
+ void AverageLagTracker::CalculateAndReportAverageLagUma(bool send_anyway) {
+-  DCHECK(!frame_lag_infos_.empty());
++  // TODO(crbug.com/1356794): re-enable DCHECK and remove early-out
++  // once bugs are fixed.
++  // DCHECK(!frame_lag_infos_.empty());
++  if (frame_lag_infos_.empty()) {
++    return;
++  }
+   const LagAreaInFrame& frame_lag = frame_lag_infos_.front();
+ 
+-  DCHECK_GE(frame_lag.lag_area, 0.f);
+-  DCHECK_GE(frame_lag.lag_area_no_prediction, 0.f);
++  // TODO(crbug.com/1356794): re-enable DCHECKs once bugs are fixed.
++  // DCHECK_GE(frame_lag.lag_area, 0.f);
++  // DCHECK_GE(frame_lag.lag_area_no_prediction, 0.f);
+   accumulated_lag_ += frame_lag.lag_area;
+   accumulated_lag_no_prediction_ += frame_lag.lag_area_no_prediction;
+ 
+   if (is_begin_) {
+-    DCHECK_EQ(accumulated_lag_, accumulated_lag_no_prediction_);
++    // TODO(crbug.com/1356794): re-enable DCHECK once bugs are fixed.
++    // DCHECK_EQ(accumulated_lag_, accumulated_lag_no_prediction_);
+   }
+ 
+   // |send_anyway| is true when we are flush all remaining frames on next

--- a/src/electron/patches/chromium/ignore_mouse_wheel_dcheck.patch
+++ b/src/electron/patches/chromium/ignore_mouse_wheel_dcheck.patch
@@ -1,0 +1,21 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Chase <chase@macro.com>
+Date: Mon, 30 Oct 2020 17:46:17 -0700
+Subject: pepper plugin support
+
+Relatively useless and a follow up to the upstream dcheck ignore
+
+diff --git a/third_party/blink/renderer/core/input/mouse_wheel_event_manager.cc b/third_party/blink/renderer/core/input/mouse_wheel_event_manager.cc
+index b1a79ed..0376cbf 100644
+--- a/third_party/blink/renderer/core/input/mouse_wheel_event_manager.cc
++++ b/third_party/blink/renderer/core/input/mouse_wheel_event_manager.cc
+@@ -79,7 +79,8 @@ WebInputEventResult MouseWheelEventManager::HandleWheelEvent(
+   if ((event.phase & kWheelEventPhaseNoEventMask) ||
+       (event.momentum_phase & kWheelEventPhaseNoEventMask)) {
+     // Filter wheel events with zero deltas and reset the wheel_target_ node.
+-    DCHECK(!event.delta_x && !event.delta_y);
++    // Annoying crash that doesn't actually help anyone
++    // DCHECK(!event.delta_x && !event.delta_y);
+     return WebInputEventResult::kNotHandled;
+   }
+ 


### PR DESCRIPTION
To apply these patches without syncing again:
```
cd src
patch -p1 < electron/patches/chromium/cherry-pick-db31a3b7bf33.patch
patch -p1 < ignore_mouse_wheel_dcheck.patch
```

@synoet @gbirman @seanaye 

If you are working on ELOK and get a crash due to this `[FATAL:average_lag_tracker.cc(171)] Check failed: frame_lag.lag_area >= 0.f`, apply the patch as above and run the build again.