### PR TITLE
Add manual release workflow for cases where one platform build fails

### DIFF
--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -1,0 +1,24 @@
+name: Manual Trigger for Publish
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version'
+        required: true
+        default: 'v20.3.0-rc'
+
+jobs:
+  generate_sha:
+    name: Generate SHA
+    uses: ./.github/workflows/generate-sha.yml
+    with:
+      version: ${{ github.event.inputs.version }}
+  publish:
+    name: Publish Electron to NPM Registry
+    needs: [generate_sha]
+    uses: ./.github/workflows/publish.yml
+    with:
+      version: ${{ github.event.inputs.version }}
+    secrets:
+      NPM_AUTH: ${{ secrets.NPM_AUTH }}


### PR DESCRIPTION
…and we don't care