### PR TITLE
Prevent `libreoffice` global from clearing after `window.close()`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,9 +29,11 @@ jobs:
           - name: Windows x64
             os: macro-windows
             runner: WINDOWS_RUNNER_INSTANCE_ID
+            working_dir: el
           - name: Linux x64
             os: macro-linux
             runner: LINUX_RUNNER_INSTANCE_ID
+            working_dir: el
     name: Build for ${{ matrix.name }}
     uses: ./.github/workflows/build.yml
     with:

--- a/qa/index.html
+++ b/qa/index.html
@@ -53,6 +53,7 @@
     </div>
     <div style="display: flex">
       <button type="button" onclick="iframewin()">Open iframe win</button>
+      <button type="button" onclick="closeiframewin()">Close iframe win</button>
       <!-- <button type="button" onclick="applyDefinitions()">Apply definitions</button> -->
       <!--   <button type="button" onclick="gotoOverlay()">Go To Overlay</button> -->
     </div>

--- a/qa/index.js
+++ b/qa/index.js
@@ -156,13 +156,17 @@ function insertTable() {
     Col: { value: 3, type: 'long' },
   });
 }
+let winhandle;
 function iframewin() {
   const url = 'https://github.com/coparse-inc/electron-libreoffice';
-  const winhandle = window.open('about:blank', 'bug_dialog', 'nodeIntegration=no');
+  winhandle = window.open('about:blank', 'bug_dialog', 'nodeIntegration=no');
   winhandle.focus();
   const iFrameStyle =
     'position:fixed; top:0; left:0; bottom:0; right:0; width:100%; height:100%; border:none; margin:0; padding:0; overflow:hidden; z-index:999999;';
   winhandle.document.write(
     `<iframe src="${url}" style="${iFrameStyle}"}></iframe>`
   );
+}
+function closeiframewin() {
+  winhandle.close();
 }


### PR DESCRIPTION
# Summary of PR
Ref count per-process, because thread local storage is unreliable and causes the global libreoffice to unset