### PR TITLE
Revert "Prevent `libreoffice` global from clearing after `window.close()`"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,11 +29,9 @@ jobs:
           - name: Windows x64
             os: macro-windows
             runner: WINDOWS_RUNNER_INSTANCE_ID
-            working_dir: el
           - name: Linux x64
             os: macro-linux
             runner: LINUX_RUNNER_INSTANCE_ID
-            working_dir: el
     name: Build for ${{ matrix.name }}
     uses: ./.github/workflows/build.yml
     with:

--- a/qa/index.html
+++ b/qa/index.html
@@ -53,7 +53,6 @@
     </div>
     <div style="display: flex">
       <button type="button" onclick="iframewin()">Open iframe win</button>
-      <button type="button" onclick="closeiframewin()">Close iframe win</button>
       <!-- <button type="button" onclick="applyDefinitions()">Apply definitions</button> -->
       <!--   <button type="button" onclick="gotoOverlay()">Go To Overlay</button> -->
     </div>

--- a/qa/index.js
+++ b/qa/index.js
@@ -156,17 +156,13 @@ function insertTable() {
     Col: { value: 3, type: 'long' },
   });
 }
-let winhandle;
 function iframewin() {
   const url = 'https://github.com/coparse-inc/electron-libreoffice';
-  winhandle = window.open('about:blank', 'bug_dialog', 'nodeIntegration=no');
+  const winhandle = window.open('about:blank', 'bug_dialog', 'nodeIntegration=no');
   winhandle.focus();
   const iFrameStyle =
     'position:fixed; top:0; left:0; bottom:0; right:0; width:100%; height:100%; border:none; margin:0; padding:0; overflow:hidden; z-index:999999;';
   winhandle.document.write(
     `<iframe src="${url}" style="${iFrameStyle}"}></iframe>`
   );
-}
-function closeiframewin() {
-  winhandle.close();
 }

--- a/src/electron/office/office_client.cc
+++ b/src/electron/office/office_client.cc
@@ -81,8 +81,6 @@ static void GetOfficeHandle(v8::Local<v8::Name> name,
 }
 }  // namespace
 
-base::AtomicRefCount g_client_counter{0};
-
 // static
 void OfficeClient::InstallToContext(v8::Local<v8::Context> context) {
   v8::Context::Scope context_scope(context);
@@ -104,7 +102,6 @@ void OfficeClient::InstallToContext(v8::Local<v8::Context> context) {
           GetOfficeHandle, nullptr, v8::MaybeLocal<v8::Value>(),
           v8::AccessControl::ALL_CAN_READ, v8::PropertyAttribute::ReadOnly)
       .Check();
-	g_client_counter.Increment();
 }
 
 void OfficeClient::Unset() {
@@ -114,11 +111,9 @@ void OfficeClient::Unset() {
 
 // static
 void OfficeClient::RemoveFromContext(v8::Local<v8::Context> /*context*/) {
-	if (!g_client_counter.Decrement()) {
-		if (lazy_tls->Get())
-			lazy_tls->Get()->Unset();
-		lazy_tls->Set(nullptr);
-	}
+  if (lazy_tls->Get())
+    lazy_tls->Get()->Unset();
+  lazy_tls->Set(nullptr);
 }
 
 OfficeClient::OfficeClient()


### PR DESCRIPTION
Was not supposed to merge chase's PR. did it by accident. Damage control